### PR TITLE
prevented evaluation of 'ENV.fetch(REDIS_URL)' if not needed

### DIFF
--- a/lib/rack/session/redic.rb
+++ b/lib/rack/session/redic.rb
@@ -48,7 +48,7 @@ module Rack
 
         @expires = options[:expire_after]
         @marshaller = options.fetch(:marshaller, Marshal)
-        @storage = ::Redic.new(options.fetch(:url, ENV.fetch(REDIS_URL)))
+        @storage = ::Redic.new(options.fetch(:url) { |k| ENV.fetch(REDIS_URL) })
       end
 
       # Generate a session ID that doesn't already exist.

--- a/lib/rack/session/redic.rb
+++ b/lib/rack/session/redic.rb
@@ -48,7 +48,7 @@ module Rack
 
         @expires = options[:expire_after]
         @marshaller = options.fetch(:marshaller, Marshal)
-        @storage = ::Redic.new(options.fetch(:url) { |k| ENV.fetch(REDIS_URL) })
+        @storage = ::Redic.new(options.fetch(:url) { ENV.fetch(REDIS_URL) })
       end
 
       # Generate a session ID that doesn't already exist.


### PR DESCRIPTION
With the new code the environment variable "REDIS_URL" only has to be evaluated when options does not contain an url.
Previously we alway hat to set the REDIS_URL to prevent a KeyError.
We can not set a single REDIS_URL because we are currently using 10 redis databases in our application.